### PR TITLE
poi-map-component.ts: Match verb tense of color and grayscale

### DIFF
--- a/scaffolder-templates/poi-map/skeleton/src/app/components/poi-map/poi-map.component.ts
+++ b/scaffolder-templates/poi-map/skeleton/src/app/components/poi-map/poi-map.component.ts
@@ -48,7 +48,7 @@ export class PoiMapComponent implements AfterViewInit {
     );
 
     this.baseLayers = {
-      colored: this.coloredLayer,
+      color: this.coloredLayer,
       grayscale: this.grayscaleLayer,
     };
 


### PR DESCRIPTION
s/colored/color/ to match verb tense of *grayscale* (cf *grayscaled*).

Done in laziest way to touch minimal lines. Could be changed throughout for slight gain in maintainability.

Tested, see: http://poi-map-app-joshix.apps.summit23-dr.w6gk.p1.openshiftapps.com/