### PR TITLE
no carrots

### DIFF
--- a/scaffolder-templates/poi-backend/template.yaml
+++ b/scaffolder-templates/poi-backend/template.yaml
@@ -26,7 +26,7 @@ spec:
         repoName:
           title: Repository Name
           type: string
-          default: <NAMESPACE>-backend
+          default: NAMESPACE-backend
         description:
           title: Description
           type: string
@@ -52,7 +52,7 @@ spec:
           title: Namespace
           type: string
           description: Namespace
-          default: <NAMESPACE>
+          default: NAMESPACE
         owner:
           title: Owner
           type: string
@@ -75,7 +75,7 @@ spec:
         image_name:
           title: Image Name
           type: string
-          default: <NAMESPACE>/poi-backend-app
+          default: NAMESPACE/poi-backend-app
           description: Image name to use for storing in the internal registry
         image_tag:
           title: Image Tag

--- a/scaffolder-templates/poi-gateway/template.yaml
+++ b/scaffolder-templates/poi-gateway/template.yaml
@@ -26,7 +26,7 @@ spec:
         repoName:
           title: Repository Name
           type: string
-          default: <NAMESPACE>-gateway
+          default: NAMESPACE-gateway
         description:
           title: Description
           type: string
@@ -52,7 +52,7 @@ spec:
           title: Namespace
           type: string
           description: Namespace
-          default: <NAMESPACE>
+          default: NAMESPACE
         owner:
           title: Owner
           type: string
@@ -75,7 +75,7 @@ spec:
         image_name:
           title: Image Name
           type: string
-          default: <NAMESPACE>/poi-gateway-app
+          default: NAMESPACE/poi-gateway-app
           description: Image name to use for storing in the internal registry
         image_tag:
           title: Image Tag

--- a/scaffolder-templates/poi-map/template.yaml
+++ b/scaffolder-templates/poi-map/template.yaml
@@ -25,7 +25,7 @@ spec:
         repoName:
           title: Repository Name
           type: string
-          default: <NAMESPACE>-frontend
+          default: NAMESPACE-frontend
         description:
           title: Description
           type: string
@@ -51,7 +51,7 @@ spec:
           title: Namespace
           type: string
           description: Namespace
-          default: <NAMESPACE>
+          default: NAMESPACE
         owner:
           title: Owner
           type: string
@@ -74,7 +74,7 @@ spec:
         image_name:
           title: Image Name
           type: string
-          default: <NAMESPACE>/poi-map-app
+          default: NAMESPACE/poi-map-app
           description: Image name to use for storing in the internal registry
         image_tag:
           title: Image Tag


### PR DESCRIPTION
Since all the input text tends to be lower case, I think it's just as clear for the reader if we don't include the carrots surrounding the \<VARIABLENAMES\>