### PR TITLE
Removing deployment from template output

### DIFF
--- a/scaffolder-templates/poi-backend/template.yaml
+++ b/scaffolder-templates/poi-backend/template.yaml
@@ -159,8 +159,6 @@ spec:
         url: ${{steps.publishSource.output.remoteUrl}}
       - title: Pipeline status
         url: https://console-openshift-console${{parameters.cluster_id}}/dev-pipelines/ns/${{parameters.namespace}}/
-      - title: Deployment details
-        url: https://console-openshift-console${{parameters.cluster_id}}/k8s/ns/${{parameters.namespace}}/deployments/${{parameters.component_id}}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{steps.registerSource.output.entityRef}}

--- a/scaffolder-templates/poi-gateway/template.yaml
+++ b/scaffolder-templates/poi-gateway/template.yaml
@@ -159,8 +159,6 @@ spec:
         url: ${{steps.publishSource.output.remoteUrl}}
       - title: Pipeline status
         url: https://console-openshift-console${{parameters.cluster_id}}/dev-pipelines/ns/${{parameters.namespace}}/
-      - title: Deployment details
-        url: https://console-openshift-console${{parameters.cluster_id}}/k8s/ns/${{parameters.namespace}}/deployments/${{parameters.component_id}}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{steps.registerSource.output.entityRef}}

--- a/scaffolder-templates/poi-map/template.yaml
+++ b/scaffolder-templates/poi-map/template.yaml
@@ -158,8 +158,6 @@ spec:
         url: ${{steps.publishSource.output.remoteUrl}}
       - title: Pipeline status
         url: https://console-openshift-console${{parameters.cluster_id}}/dev-pipelines/ns/${{parameters.namespace}}/
-      - title: Deployment details
-        url: https://console-openshift-console${{parameters.cluster_id}}/k8s/ns/${{parameters.namespace}}/deployments/${{parameters.component_id}}
       - title: Open Component in catalog
         icon: catalog
         entityRef: ${{steps.registerSource.output.entityRef}}


### PR DESCRIPTION
Removing as the deployment page is not available right away.  Better to encourage the user to access deployments via the catalog item overview page.